### PR TITLE
Update for Swift 5 and fix bugs from iOS 12 SDK

### DIFF
--- a/Example/HideShowPasswordTextFieldExample/HideShowPasswordTextFieldExample.xcodeproj/project.pbxproj
+++ b/Example/HideShowPasswordTextFieldExample/HideShowPasswordTextFieldExample.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -331,6 +332,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Guidebook.HideShowPasswordTextFieldExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -342,6 +344,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Guidebook.HideShowPasswordTextFieldExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Example/HideShowPasswordTextFieldExample/HideShowPasswordTextFieldExample/ViewController.swift
+++ b/Example/HideShowPasswordTextFieldExample/HideShowPasswordTextFieldExample/ViewController.swift
@@ -23,22 +23,11 @@ class ViewController: UIViewController {
     }
 }
 
-// MARK: UITextFieldDelegate
-extension ViewController: UITextFieldDelegate {
-    func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, textField string: String) -> Bool {
-        return passwordTextField.textField(textField: textField, shouldChangeCharactersInRange: range, replacementString: string)
-    }
-    
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        passwordTextField.textFieldDidEndEditing(textField: textField)
-    }
-}
-
 // MARK: HideShowPasswordTextFieldDelegate
 // Implementing this delegate is entirely optional.  
 // It's useful when you want to show the user that their password is valid.
 extension ViewController: HideShowPasswordTextFieldDelegate {
-    func isValidPassword(password: String) -> Bool {
+    func isValidPassword(_ password: String) -> Bool {
         return password.count > 7
     }
 }
@@ -47,7 +36,6 @@ extension ViewController: HideShowPasswordTextFieldDelegate {
 extension ViewController {
     private func setupPasswordTextField() {
         passwordTextField.passwordDelegate = self
-        passwordTextField.delegate = self
         passwordTextField.borderStyle = .none
         passwordTextField.clearButtonMode = .whileEditing
         passwordTextField.layer.borderWidth = 0.5
@@ -57,10 +45,5 @@ extension ViewController {
         passwordTextField.layer.cornerRadius = 0
         
         passwordTextField.rightView?.tintColor = UIColor(red: 0.204, green: 0.624, blue: 0.847, alpha: 1)
-        
-        
-        // left view hack to add padding
-        passwordTextField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 3))
-        passwordTextField.leftViewMode = .always
     }
 }

--- a/HideShowPasswordTextField/HideShowPasswordTextField.swift
+++ b/HideShowPasswordTextField/HideShowPasswordTextField.swift
@@ -13,7 +13,7 @@ protocol HideShowPasswordTextFieldDelegate: class {
     func isValidPassword(_ password: String) -> Bool
 }
 
-class HideShowPasswordTextField: UITextField {
+public class HideShowPasswordTextField: UITextField {
     weak var passwordDelegate: HideShowPasswordTextFieldDelegate?
     var preferredFont: UIFont? {
         didSet {
@@ -24,7 +24,7 @@ class HideShowPasswordTextField: UITextField {
         }
     }
     
-    override var isSecureTextEntry: Bool {
+    override public var isSecureTextEntry: Bool {
         didSet {
             if !self.isSecureTextEntry {
                 self.font = nil
@@ -49,12 +49,12 @@ class HideShowPasswordTextField: UITextField {
         super.init(coder: aDecoder)
     }
     
-    override func awakeFromNib() {
+    override public func awakeFromNib() {
         super.awakeFromNib()
         setupViews()
     }
     
-    override func becomeFirstResponder() -> Bool {
+    override public func becomeFirstResponder() -> Bool {
         // Hack to prevent text from getting cleared when switching secure entry
         // https://stackoverflow.com/a/49771445/1417922
         let success = super.becomeFirstResponder()

--- a/HideShowPasswordTextField/PasswordToggleVisibilityView.swift
+++ b/HideShowPasswordTextField/PasswordToggleVisibilityView.swift
@@ -10,15 +10,15 @@ import Foundation
 import UIKit
 
 protocol PasswordToggleVisibilityDelegate: class {
-    func viewWasToggled(passwordToggleVisibilityView: PasswordToggleVisibilityView, isSelected selected: Bool)
+    func viewWasToggled(_ passwordToggleVisibilityView: PasswordToggleVisibilityView, isSelected selected: Bool)
 }
 
 class PasswordToggleVisibilityView: UIView {
-    private let eyeOpenedImage: UIImage
-    private let eyeClosedImage: UIImage
-    private let checkmarkImage: UIImage
-    private let eyeButton: UIButton
-    private let checkmarkImageView: UIImageView
+    fileprivate let eyeOpenedImage: UIImage
+    fileprivate let eyeClosedImage: UIImage
+    fileprivate let checkmarkImage: UIImage
+    fileprivate let eyeButton: UIButton
+    fileprivate let checkmarkImageView: UIImageView
     weak var delegate: PasswordToggleVisibilityDelegate?
     
     enum EyeState {
@@ -37,7 +37,11 @@ class PasswordToggleVisibilityView: UIView {
     
     var checkmarkVisible: Bool {
         set {
-            checkmarkImageView.isHidden = !newValue
+            let isHidden = !newValue
+            guard checkmarkImageView.isHidden != isHidden else {
+                return
+            }
+            checkmarkImageView.isHidden = isHidden
         }
         get {
             return !checkmarkImageView.isHidden
@@ -53,7 +57,7 @@ class PasswordToggleVisibilityView: UIView {
     
     override init(frame: CGRect) {
         self.eyeOpenedImage = UIImage(named: "ic_eye_open")!.withRenderingMode(.alwaysTemplate)
-        self.eyeClosedImage = UIImage(named: "ic_eye_closed")!
+        self.eyeClosedImage = UIImage(named: "ic_eye_closed")!.withRenderingMode(.alwaysTemplate)
         self.checkmarkImage = UIImage(named: "ic_password_checkmark")!.withRenderingMode(.alwaysTemplate)
         self.eyeButton = UIButton(type: .custom)
         self.checkmarkImageView = UIImageView(image: self.checkmarkImage)
@@ -65,16 +69,16 @@ class PasswordToggleVisibilityView: UIView {
         fatalError("Don't use init with coder.")
     }
     
-    private func setupViews() {
+    fileprivate func setupViews() {
         let padding: CGFloat = 10
         let buttonWidth = (frame.width / 2) - padding
         let buttonFrame = CGRect(x: buttonWidth + padding, y: 0, width: buttonWidth, height: frame.height)
         eyeButton.frame = buttonFrame
         eyeButton.backgroundColor = UIColor.clear
         eyeButton.adjustsImageWhenHighlighted = false
-        eyeButton.setImage(self.eyeClosedImage, for: .normal)
+        eyeButton.setImage(self.eyeClosedImage, for: UIControl.State())
         eyeButton.setImage(self.eyeOpenedImage.withRenderingMode(.alwaysTemplate), for: .selected)
-        eyeButton.addTarget(self, action: #selector(eyeButtonPressed), for: .touchUpInside)
+        eyeButton.addTarget(self, action: #selector(PasswordToggleVisibilityView.eyeButtonPressed(_:)), for: .touchUpInside)
         eyeButton.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         eyeButton.tintColor = self.tintColor
         self.addSubview(eyeButton)
@@ -87,13 +91,13 @@ class PasswordToggleVisibilityView: UIView {
         checkmarkImageView.backgroundColor = UIColor.clear
         checkmarkImageView.tintColor = self.tintColor
         self.addSubview(checkmarkImageView)
+        
+        self.checkmarkImageView.isHidden = true
     }
     
     
-    @objc func eyeButtonPressed(sender: AnyObject) {
+    @objc func eyeButtonPressed(_ sender: AnyObject) {
         eyeButton.isSelected = !eyeButton.isSelected
-        delegate?.viewWasToggled(passwordToggleVisibilityView: self, isSelected: eyeButton.isSelected)
+        delegate?.viewWasToggled(self, isSelected: eyeButton.isSelected)
     }
 }
-
-// Animation helpers

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Just add the files in `HideShowPasswordTextField/` to your project.
 * Create a `UITextField` in your xib, and change the class name to `HideShowPasswordTextField`.  Or, create it programatically.
 * Set `secureTextEntry` to `true`, if you want the password to hide by default.
 * [Recommended] Change the border style to None, and add a height constraint of 44 or larger.  The assets in this project are optimized for 44px, although larger is fine too.  Smaller sizes might have clipping issues on the icons.
-* Implement `UITextFieldDelegate` and forward `textField shouldChangeCharactersInRange` and `textFieldDidEndEditing` to your password text field (see the example).  We have to do this to get the behavior to work right--apple's API doesn't play very nice switching between `secureTextEntry` states.
+* ~Implement `UITextFieldDelegate` and forward `textField shouldChangeCharactersInRange` and `textFieldDidEndEditing` to your password text field (see the example).  We have to do this to get the behavior to work right--apple's API doesn't play very nice switching between `secureTextEntry` states.~
+  * This step is no longer necessary.
 * [Optional] Implement `HideShowPasswordTextFieldDelegate` to show the validation checkbox.
 * Customize the textField to your liking (the tint too!)!


### PR DESCRIPTION
## What
* Make `HideShowPasswordTextField` explicitly `public`.
* Update the hacky-ish logic to be more isolated and slightly less hacky (it was also not working with iOS 12 SDK)
* Remove need to implement `UITextFieldDelegate` when using this view
* Update example to use Swift 5

## Why
* Compatibility for Swift 5 + Xcode 10.2.1 and make it slightly more usable